### PR TITLE
Publish to  PyPI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
     - name: Build Binary
-      run: |
-        pyinstaller --clean --hidden-import one.__main__ cli.py --onefile --noconsole -n one
+      run: pyinstaller --clean --hidden-import one.__main__ cli.py --onefile --noconsole -n one
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,0 +1,29 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  build:
+
+    name: Build and publish distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip setuptools wheel twine
+    - name: Build a binary wheel and a source tarball
+      run: python setup.py sdist bdist_wheel
+    - name: Publish distribution to PyPI
+      run: python -m twine upload dist/*
+      env:
+        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/publish-test-pypi.yaml
+++ b/.github/workflows/publish-test-pypi.yaml
@@ -1,0 +1,29 @@
+name: Publish to Test PyPI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  build:
+
+    name: Build and publish distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip setuptools wheel twine
+    - name: Build a binary wheel and a source tarball
+      run: python setup.py sdist bdist_wheel
+    - name: Publish distribution to PyPI
+      run: python -m twine upload --repository testpypi dist/*
+      env:
+        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,15 +1,17 @@
+name: Upload Release Asset
+
 on:
   push:
     tags:
       - '*'
 
-name: Upload Release Asset
-
 jobs:
 
   create_release:
+
     name: Create Release
     runs-on: [macOS-latest]
+
     steps:
       - name: Check out code
         uses: actions/checkout@v1
@@ -35,12 +37,14 @@ jobs:
           path: release_url.txt
 
   build_and_upload:
-    needs: [create_release]
+
     name: Build and Upload Release Asset
+    needs: [create_release]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 CLI to manage all stacks from DNX.
 
 ![Build](https://github.com/DNXLabs/one-cli/workflows/Build/badge.svg)
+[![PyPI](https://badge.fury.io/py/one-cli.svg)](https://pypi.python.org/pypi/one-cli/)
 [![LICENSE](https://img.shields.io/github/license/DNXLabs/one-cli)](https://github.com/DNXLabs/one-cli/blob/master/LICENSE)
 
 ## Quick start

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+pyinstaller --clean --hidden-import one.__main__ cli.py --onefile --noconsole -n one
+
+sudo rm -rf /usr/local/bin/one
+
+sudo mv ./dist/one /usr/local/bin/one
+
+sudo chmod +x /usr/local/bin/one

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-__version__ = '0.4.3'
+__version__ = '0.4.4'
 
 home = str(Path.home())
 


### PR DESCRIPTION
This pull request adds the workflow to publish the CLI to PyPI.

Still need to be tested, but to do that first:
- [x] Account needs to be created at PyPI.
- [x] Username replaced in the commit.
- [x] Add password as a token to Github secrets.

```
password: ${{ secrets.pypi_password }}
```