### PR TITLE
Creates init config file entrypoint

### DIFF
--- a/one.yaml
+++ b/one.yaml
@@ -1,0 +1,11 @@
+images:
+  azure: dnxsolutions/docker-aws-azure-ad:latest
+  gsuite: dnxsolutions/aws-google-auth:latest
+  terraform: dnxsolutions/terraform:0.12.20-dnx1
+workspaces:
+  ASDF:
+    aws-account-id: ASDF
+    aws-role: ASDF
+  asd:
+    aws-account-id: asd
+    aws-role: asd

--- a/one/commands/init.py
+++ b/one/commands/init.py
@@ -5,12 +5,6 @@ from one.utils.prompt import style
 from one.docker.image import AZURE_AUTH_IMAGE, GSUITE_AUTH_IMAGE, TERRAFORM_IMAGE
 from one.__init__ import CONFIG_FILE
 
-images = {
-    'terraform': TERRAFORM_IMAGE,
-    'gsuite': GSUITE_AUTH_IMAGE,
-    'azure': AZURE_AUTH_IMAGE
-}
-
 creation_question =  [
     {
         'type': 'input',
@@ -18,6 +12,30 @@ creation_question =  [
         'message': 'Do you want to create workspaces now? [Y/n]',
         'default': 'Y'
     }
+]
+
+image_questions = [
+    {
+        'type': 'input',
+        'name': 'terraform',
+        'default': TERRAFORM_IMAGE,
+        'message': 'Terraform docker image:',
+        'validate': lambda text: len(text) >= 4 or 'Must be at least 4 character.'
+    },
+    {
+        'type': 'input',
+        'name': 'gsuite',
+        'default': GSUITE_AUTH_IMAGE,
+        'message': 'G Suite docker image:',
+        'validate': lambda text: len(text) >= 4 or 'Must be at least 4 character.'
+    },
+    {
+        'type': 'input',
+        'name': 'azure',
+        'default': AZURE_AUTH_IMAGE,
+        'message': 'Azure docker image:',
+        'validate': lambda text: len(text) >= 4 or 'Must be at least 4 character.'
+    },
 ]
 
 workspace_questions = [
@@ -59,6 +77,13 @@ def init():
     create_workspace = create_answer['create'].lower()
     workspaces = {}
     if create_workspace == 'y' or not create_workspace:
+        image_answers = prompt(image_questions, style=style)
+        images = {
+            'terraform': image_answers['terraform'],
+            'gsuite': image_answers['gsuite'],
+            'azure': image_answers['azure']
+        }
+
         while True:
             workspace_answers = prompt(workspace_questions, style=style)
             if workspace_answers['assume_role'].lower() == 'y' or not workspace_answers['assume_role']:

--- a/one/commands/init.py
+++ b/one/commands/init.py
@@ -1,0 +1,65 @@
+import click
+from PyInquirer import prompt
+import yaml
+from one.utils.prompt import style
+from one.docker.image import AZURE_AUTH_IMAGE, GSUITE_AUTH_IMAGE, TERRAFORM_IMAGE
+from one.__init__ import CONFIG_FILE
+
+images = {
+    'terraform': TERRAFORM_IMAGE,
+    'gsuite': GSUITE_AUTH_IMAGE,
+    'azure': AZURE_AUTH_IMAGE
+}
+
+creation_question =  [
+    {
+        'type': 'input',
+        'name': 'create',
+        'message': 'Do you want to create workspaces now? [Y/n]'
+    }
+]
+
+workspace_questions = [
+    {
+        'type': 'input',
+        'name': 'AWS_ACCOUNT_ID',
+        'message': 'What\'s your AWS_ACCOUNT_ID credential:',
+        'validate': lambda text: len(text) >= 1 or 'Must be at least 1 character.'
+    },
+    {
+        'type': 'input',
+        'name': 'AWS_ROLE',
+        'message': 'What\'s your AWS_ROLE credential:',
+        'validate': lambda text: len(text) >= 1 or 'Must be at least 1 character.'
+    },
+    {
+        'type': 'input',
+        'name': 'WORKSPACE',
+        'message': 'What\'s your WORKSPACE credential:',
+        'validate': lambda text: len(text) >= 1 or 'Must be at least 1 character.'
+    },
+    {
+        'type': 'input',
+        'name': 'new_workspace',
+        'message': 'Do you want to create another workspace? [Y/n]'
+    }
+]
+
+@click.command(help='Create config file for CLI in current directory.')
+def init():
+    create_answer = prompt(creation_question, style=style)
+    create_workspace = create_answer['create'].lower()
+    workspaces = {}
+    if create_workspace == 'y' or not create_workspace:
+        while True:
+            workspace_answers = prompt(workspace_questions, style=style)
+            workspace = {
+                            'aws-role': workspace_answers['AWS_ROLE'],
+                            'aws-account-id': workspace_answers['AWS_ACCOUNT_ID']
+                        }
+            workspaces[workspace_answers['WORKSPACE']] = workspace
+            if workspace_answers['new_workspace'].lower() == 'n':
+                break
+        with open(CONFIG_FILE, 'w') as file:
+            content = {'images': images, 'workspaces': workspaces}
+            yaml.dump(content, file)

--- a/one/commands/init.py
+++ b/one/commands/init.py
@@ -15,7 +15,8 @@ creation_question =  [
     {
         'type': 'input',
         'name': 'create',
-        'message': 'Do you want to create workspaces now? [Y/n]'
+        'message': 'Do you want to create workspaces now? [Y/n]',
+        'default': 'Y'
     }
 ]
 
@@ -40,7 +41,14 @@ workspace_questions = [
     },
     {
         'type': 'input',
+        'name': 'assume_role',
+        'default': 'n',
+        'message': 'Do you want to this workspace to assume role? [Y/n]'
+    },
+    {
+        'type': 'input',
         'name': 'new_workspace',
+        'default': 'Y',
         'message': 'Do you want to create another workspace? [Y/n]'
     }
 ]
@@ -53,9 +61,14 @@ def init():
     if create_workspace == 'y' or not create_workspace:
         while True:
             workspace_answers = prompt(workspace_questions, style=style)
+            if workspace_answers['assume_role'].lower() == 'y' or not workspace_answers['assume_role']:
+                assume_role = True
+            else:
+                assume_role = False
             workspace = {
                             'aws-role': workspace_answers['AWS_ROLE'],
-                            'aws-account-id': workspace_answers['AWS_ACCOUNT_ID']
+                            'aws-account-id': workspace_answers['AWS_ACCOUNT_ID'],
+                            'assume-role': assume_role
                         }
             workspaces[workspace_answers['WORKSPACE']] = workspace
             if workspace_answers['new_workspace'].lower() == 'n':

--- a/one/one.py
+++ b/one/one.py
@@ -20,6 +20,7 @@ from one.commands.terraform import terraform
 from one.commands.workspace import workspace
 from one.commands.idp import idp
 from one.commands.update import update
+from one.commands.init import init
 
 
 @click.version_option(__version__)
@@ -34,6 +35,7 @@ cli.add_command(terraform)
 cli.add_command(workspace)
 cli.add_command(idp)
 cli.add_command(update)
+cli.add_command(init)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces the subcommand `one init`, that will ask the user about the workspaces  and configuration and then create the `one.yaml` config file inside the current folder.

The last thing missing is to allow the user to change the images that are not implemented yet.

