### PR TITLE
Add Okta SSO to list of IDP providers from One CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ one/__main__.pyc
 one/one.pyc
 env
 one_cli.egg-info
+.one
+one.yaml

--- a/one/commands/auth.py
+++ b/one/commands/auth.py
@@ -75,7 +75,7 @@ def azure():
 
 
 @auth.command(help='Authentication using Okta SSO provider.')
-def okta(auth_image=None):
+def okta():
     if not check_config_file(['idp']):
         configure_okta()
     auth_image = image.get_image('okta')

--- a/one/commands/auth.py
+++ b/one/commands/auth.py
@@ -10,7 +10,13 @@ from one.utils.prompt import style
 from one.prompt.auth import get_sso_profile_questions, get_iam_profile_questions
 from one.__init__ import CLI_ROOT
 from one.utils.environment.common import create_secrets, get_credentials_file, get_config_file, get_idp_file
-from one.utils.environment.idp import configure_idp, configure_gsuite, configure_azure, configure_okta, configure_aws_sso, configure_iam_user
+from one.utils.environment.idp import (configure_idp,
+                                       configure_gsuite,
+                                       configure_azure,
+                                       configure_okta,
+                                       configure_aws_sso,
+                                       configure_iam_user)
+
 
 container = Container()
 image = Image()

--- a/one/docker/image.py
+++ b/one/docker/image.py
@@ -7,6 +7,7 @@ from requests.exceptions import ConnectionError
 
 GSUITE_AUTH_IMAGE = 'dnxsolutions/aws-google-auth:latest'
 AZURE_AUTH_IMAGE = 'dnxsolutions/docker-aws-azure-ad:latest'
+OKTA_AUTH_IMAGE = 'dnxsolutions/aws-okta-auth:latest'
 TERRAFORM_IMAGE = 'dnxsolutions/terraform:0.13.0-dnx1'
 AWS_IMAGE = 'dnxsolutions/aws:1.18.44-dnx2'
 AWS_V2_IMAGE = 'dnxsolutions/aws:2.0.37-dnx1'
@@ -23,6 +24,7 @@ class Image:
         images = {'terraform': TERRAFORM_IMAGE,
                   'gsuite': GSUITE_AUTH_IMAGE,
                   'azure': AZURE_AUTH_IMAGE,
+                  'okta': OKTA_AUTH_IMAGE,
                   'aws': AWS_IMAGE,
                   'aws_v2': AWS_V2_IMAGE,
                   'shell': SHELL_IMAGE,

--- a/one/prompt/idp.py
+++ b/one/prompt/idp.py
@@ -1,4 +1,10 @@
-prompt_providers = ['Google G Suite SSO', 'Microsoft Azure SSO', 'Okta SSO', 'AWS SSO', 'AWS IAM user']
+prompt_providers = [
+    'Google G Suite SSO',
+    'Microsoft Azure SSO',
+    'Okta SSO',
+    'AWS SSO',
+    'AWS IAM user'
+]
 
 PROVIDER_QUESTIONS = [
     {

--- a/one/prompt/idp.py
+++ b/one/prompt/idp.py
@@ -1,4 +1,4 @@
-prompt_providers = ['Google G Suite SSO', 'Microsoft Azure SSO', 'AWS SSO', 'AWS IAM user']
+prompt_providers = ['Google G Suite SSO', 'Microsoft Azure SSO', 'Okta SSO', 'AWS SSO', 'AWS IAM user']
 
 PROVIDER_QUESTIONS = [
     {
@@ -35,6 +35,27 @@ AZURE_QUESTIONS = [
         'type': 'input',
         'name': 'AZURE_APP_ID_URI',
         'message': 'What\'s your AZURE_APP_ID_URI credential:',
+        'validate': lambda text: len(text) >= 4 or 'Must be at least 4 characters.'
+    }
+]
+
+OKTA_QUESTIONS = [
+    {
+        'type': 'input',
+        'name': 'OKTA_ORG',
+        'message': 'What\'s your OKTA_ORG credential:',
+        'validate': lambda text: len(text) >= 4 or 'Must be at least 4 characters.'
+    },
+    {
+        'type': 'input',
+        'name': 'OKTA_AWS_APP_URL',
+        'message': 'What\'s your OKTA_AWS_APP_URL credential:',
+        'validate': lambda text: len(text) >= 4 or 'Must be at least 4 characters.'
+    },
+    {
+        'type': 'input',
+        'name': 'OKTA_AWS_DEFAULT_REGION',
+        'message': 'What\'s your OKTA_AWS_DEFAULT_REGION credential:',
         'validate': lambda text: len(text) >= 4 or 'Must be at least 4 characters.'
     }
 ]

--- a/one/utils/environment/idp.py
+++ b/one/utils/environment/idp.py
@@ -5,7 +5,7 @@ from one.utils.prompt import style
 from one.docker.image import Image
 from one.docker.container import Container
 from one.__init__ import CLI_ROOT
-from one.prompt.idp import PROVIDER_QUESTIONS, GSUITE_QUESTIONS, AZURE_QUESTIONS
+from one.prompt.idp import PROVIDER_QUESTIONS, GSUITE_QUESTIONS, AZURE_QUESTIONS, OKTA_QUESTIONS
 from one.prompt.auth import AWS_ACCESS_KEY_QUESTIONS
 
 image = Image()
@@ -21,6 +21,8 @@ def configure_idp():
         configure_gsuite()
     elif provider_answer['provider'] == 'Microsoft Azure SSO':
         configure_azure()
+    elif provider_answer['provider'] == 'Okta SSO':
+        configure_okta()
     elif provider_answer['provider'] == 'AWS SSO':
         configure_aws_sso()
     elif provider_answer['provider'] == 'AWS IAM user':
@@ -52,6 +54,21 @@ def configure_azure():
     idp_file['azure'] = {
         'AZURE_TENANT_ID': answers['AZURE_TENANT_ID'],
         'AZURE_APP_ID_URI': answers['AZURE_APP_ID_URI']
+    }
+
+    write_config(idp_file, '/idp')
+    click.echo('\n')
+
+
+def configure_okta():
+    answers = prompt(OKTA_QUESTIONS, style=style)
+    if not bool(answers):
+        raise SystemExit
+    idp_file = get_idp_file()
+    idp_file['okta'] = {
+        'okta_org': answers['OKTA_ORG'],
+        'okta_aws_app_url': answers['OKTA_AWS_APP_URL'],
+        'okta_aws_default_region': answers['OKTA_AWS_DEFAULT_REGION']
     }
 
     write_config(idp_file, '/idp')


### PR DESCRIPTION
Add Okta SSO related features to One CLI:

## Proposed Changes

    - Associate new docker image dnxsolutions/aws-okta-auth
    - Create new command **one auth okta** for authentication with new IDP
    - Create new command under **one auth configure** for Okta IDP parameters configuration