### PR TITLE
Inject extra environments to app deploy

### DIFF
--- a/one/commands/app.py
+++ b/one/commands/app.py
@@ -42,7 +42,7 @@ def docker_push(build_version):
 @click.option('-w', '--workspace', required=True, help='Workspace to deploy.')
 @click.option('--build-version', default='latest', help='Build version to deploy (default: latest).')
 def deploy_ecs(workspace, build_version):
-    app_deploy = app_deploy_factory(get_workspace_value(workspace, 'type', 'ecs'))
+    app_deploy = app_deploy_factory(get_workspace_value(workspace, 'type', 'ecs', True))
     app_registry = app_registry_factory(get_config_value('app.docker.registry_type', 'ecr'))
 
     environment.build(workspace)

--- a/one/utils/app/deploy/ecs.py
+++ b/one/utils/app/deploy/ecs.py
@@ -15,12 +15,17 @@ class AppDeployEcs(App):
 
     def deploy(self, environment, workspace, image_name):
         env_deploy = {
-            'AWS_DEFAULT_REGION': get_workspace_value(workspace, 'aws.region'),
+            'AWS_DEFAULT_REGION': get_workspace_value(workspace, 'aws.region', '', True),
             'APP_NAME': get_config_value('app.name'),
-            'CLUSTER_NAME': get_workspace_value(workspace, 'ecs_cluster_name'),
+            'CLUSTER_NAME': get_workspace_value(workspace, 'ecs_cluster_name', '', True),
             'CONTAINER_PORT': get_config_value('app.port'),
             'IMAGE_NAME': image_name,
         }
+
+        workspace_environments = get_workspace_value(workspace, 'environment', [])
+
+        for env_dict in workspace_environments:
+            env_deploy = {**env_deploy, **env_dict}
 
         ecs_task_definition_file = get_config_value('app.ecs_task_definition_file', 'task-definition.tpl.json')
         if not os.path.isfile(ecs_task_definition_file):

--- a/one/utils/app/deploy/static.py
+++ b/one/utils/app/deploy/static.py
@@ -17,13 +17,22 @@ class AppDeployStatic(App):
         workspace = environments.get('WORKSPACE', 'default')
 
         env_deploy = {
-            'AWS_DEFAULT_REGION': get_workspace_value(workspace, 'aws.region')
+            'AWS_DEFAULT_REGION': get_workspace_value(workspace, 'aws.region', '', True)
         }
         environments.update(env_deploy)
 
-        s3_bucket_name = get_config_value('app.s3_bucket', '') or get_workspace_value(workspace, 'app.s3_bucket')
-        distribution_id = get_config_value('app.distribution_id', '') or get_workspace_value(workspace, 'app.distribution_id')
-        src_dir = get_config_value('app.src', '') or get_workspace_value(workspace, 'app.src')
+        s3_bucket_name = (
+            get_config_value('app.s3_bucket', '') or
+            get_workspace_value(workspace, 'app.s3_bucket', '', True)
+        )
+        distribution_id = (
+            get_config_value('app.distribution_id', '') or
+            get_workspace_value(workspace, 'app.distribution_id', '', True)
+        )
+        src_dir = (
+            get_config_value('app.src', '') or
+            get_workspace_value(workspace, 'app.src', '', True)
+        )
 
         if not os.path.isdir(src_dir):
             click.echo('Source folder not found (%s)' % src_dir)

--- a/one/utils/config.py
+++ b/one/utils/config.py
@@ -54,7 +54,7 @@ def get_config_value(key, default=None):
     return value
 
 
-def get_workspace_value(workspace_name, variable, default=None):
+def get_workspace_value(workspace_name, variable, default=None, required=False):
     value = default
     if path.exists(CONFIG_FILE):
         with open(CONFIG_FILE) as file:
@@ -77,14 +77,13 @@ def get_workspace_value(workspace_name, variable, default=None):
                         layer = layer[key_path]
                 else:
                     break
-
-            if not value:
+            if not value and required:
                 click.echo('Missing required parameter in config: workspaces.%s.%s.' % (workspace_name, variable))
                 raise SystemExit
 
         file.close()
 
-    return str(value)
+    return value
 
 
 def get_current_workspace_value(default=None):

--- a/one/utils/environment/aws.py
+++ b/one/utils/environment/aws.py
@@ -27,8 +27,8 @@ class EnvironmentAws(Environment):
         self.workspace = workspace or getenv('WORKSPACE') or 'default'
         click.echo('Setting workspace to %s' % (self.workspace))
 
-        aws_account_id = aws_account_id or get_workspace_value(self.workspace, 'aws.account_id')
-        aws_role = aws_role or get_workspace_value(self.workspace, 'aws.role')
+        aws_account_id = aws_account_id or get_workspace_value(self.workspace, 'aws.account_id', '', True)
+        aws_role = aws_role or get_workspace_value(self.workspace, 'aws.role', '', True)
         aws_assume_role = aws_assume_role or get_workspace_value(self.workspace, 'aws.assume_role', 'false')
 
         self.env_workspace = {


### PR DESCRIPTION
Signed-off-by: Arthur Diniz <arthurbdiniz@gmail.com>

## Proposed Changes

  - Inject extra environments to app deploy
  - Add option to define if a workspace value is required or not
 

```yaml
workspaces:
  bubbletea2-services:
    aws:
      account_id: *********
      role: *********
      region: ap-southeast-2
  bubbletea2-nonprod:
    aws:
      account_id: *********
      role: *********
      region: ap-southeast-2
    environment:
      - MEMORY: 1024
      - COMMAND: apache2-foreground
      - AWS_ACCOUNT_ID: *********
      - ENVIRONMENT_NAME: dev
    ecs_cluster_name: dev-apps
```